### PR TITLE
Fix compiler warnings and errors... (memory leak?)

### DIFF
--- a/src/LongNeighborTest.cpp
+++ b/src/LongNeighborTest.cpp
@@ -483,7 +483,7 @@ namespace {
       Message base;
       bool passing ;
       for( base.length=MINMSGBYTES; base.length <= MAXMSGBYTES; base.length++ ) {
-        random.reseed(base.length);
+        random.reseed((uint64_t)base.length);
 
         for( int i=0; i<BASES_PER_LENGTH; i++ ) {
           if( i == 0 )
@@ -528,8 +528,8 @@ namespace {
     { }
 
     ~TestLongNeighbors() {
-      delete hashTable;
-      delete fullHashes;
+      delete[] hashTable;
+      delete[] fullHashes;
     }
 
     bool run() {


### PR DESCRIPTION
Hi @hmakholm ,

I saw this and loved it... but got errors while compiling.

Here were my two small things the removed the compilation messages:

1. The `random.reseed` function has two variations. The call to `random.reseed` might be ambiguous. A type cast was added to prevent ambiguity.

2. The `TestLongNeighbors` constructor uses the `new[]` operator, and I assume the `~TestLongNeighbors` destructor was meant to do the same...?

I think the LongNeighbor test should be more widespread.

I also noticed the original SMHasher repo is abandoned, but I found this fork ([rurban/smhasher](https://github.com/rurban/smhasher)) which looks far more complete and active. Maybe it could be merged there?

Anyway, thanks for authoring the test.

Kindly,
Bo.